### PR TITLE
Disable Zoom, Improved MinecraftRadialButtonPanel, Bug Fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,6 @@
     "xtr1common": "cpp",
     "xutility": "cpp",
 
-    // "*.css": "tailwindcss"
+    "*.css": "tailwindcss"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "typescript": "^4.9.5"
   },
   "scripts": {
+    "react": "npm run start-react",
+    "electron": "npm run start-electron",
     "start-react": "set BROWSER=none&& react-app-rewired start",
     "start-electron": "electron .",
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,19 @@
     "typescript": "^4.9.5"
   },
   "scripts": {
-    "start-react": "react-app-rewired start",
+    "start-react": "set BROWSER=none&& react-app-rewired start",
     "start-electron": "electron .",
+
+    "build": "npm run build-react && npm run build-electron",
+    "postbuild": "npm run built",
+    
     "build-react": "react-app-rewired build",
-    "build": "react-app-rewired build && electron-builder --win",
-    "run-built": "start ./dist/win-unpacked/Amethyst-Launcher.exe",
-    "dev": "set BROWSER=none&& start electron . & react-app-rewired start",
+    "build-electron": "electron-builder --win",
+
+    "built": "start ./dist/win-unpacked/Amethyst-Launcher.exe",
+    "run-built": "npm run built",
+    "exe": "npm run built",
+    
     "bump-version": "npm version patch --no-git-tag-version"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build-react": "react-app-rewired build",
     "build": "react-app-rewired build && electron-builder --win",
     "run-built": "start ./dist/win-unpacked/Amethyst-Launcher.exe",
+    "dev": "set BROWSER=none&& start electron . & react-app-rewired start",
     "bump-version": "npm version patch --no-git-tag-version"
   },
   "eslintConfig": {

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,4 +1,4 @@
-const {app, Menu, BrowserWindow, ipcMain, nativeTheme} = require('electron');
+const {app, Menu, BrowserWindow, ipcMain, nativeTheme, MenuItem} = require('electron');
 const path = require('path');
 const {autoUpdater} = require("electron-updater");
 
@@ -32,7 +32,9 @@ function createWindow() {
     }
 }
 
-Menu.setApplicationMenu(null);
+const windowMenu = new Menu()
+windowMenu.append(new MenuItem({ label: "Inspect", role:"toggleDevTools"}))
+Menu.setApplicationMenu(windowMenu);
 
 ipcMain.on('TITLE_BAR_ACTION', (event, args) => {
     switch (args) {

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, ipcMain, ipcRenderer, nativeTheme} = require('electron');
+const {app, Menu, BrowserWindow, ipcMain, nativeTheme} = require('electron');
 const path = require('path');
 const {autoUpdater} = require("electron-updater");
 
@@ -25,16 +25,14 @@ function createWindow() {
     mainWindow = win;
     win.setMenuBarVisibility(false);
 
-    mainWindow.webContents.on('did-finish-load', () => {
-        
-    })
-
     if (app.isPackaged) {
         win.loadURL(`file://${path.join(__dirname, '../build/index.html')}`);
     } else {
         win.loadURL('http://localhost:3000');
     }
 }
+
+Menu.setApplicationMenu(null);
 
 ipcMain.on('TITLE_BAR_ACTION', (event, args) => {
     switch (args) {

--- a/public/electron.js
+++ b/public/electron.js
@@ -33,7 +33,7 @@ function createWindow() {
 }
 
 const windowMenu = new Menu()
-windowMenu.append(new MenuItem({ label: "Inspect", role:"toggleDevTools"}))
+windowMenu.append(new MenuItem({role:"toggleDevTools"}))
 Menu.setApplicationMenu(windowMenu);
 
 ipcMain.on('TITLE_BAR_ACTION', (event, args) => {

--- a/public/electron.js
+++ b/public/electron.js
@@ -25,6 +25,10 @@ function createWindow() {
     mainWindow = win;
     win.setMenuBarVisibility(false);
 
+    mainWindow.webContents.on('did-finish-load', () => {
+        
+    })
+
     if (app.isPackaged) {
         win.loadURL(`file://${path.join(__dirname, '../build/index.html')}`);
     } else {

--- a/src/components/MinecraftRadialButton.tsx
+++ b/src/components/MinecraftRadialButton.tsx
@@ -1,31 +1,37 @@
 type RadialButtonProperties = {
     text: string,
+    value: string,
     selected: boolean,
     className?: string,
-    onChange: (text: string) => void
+    onChange: (value: string) => void
 }
 
-export default function MinecraftRadialButton({text, selected, className, onChange}: RadialButtonProperties) {
+export default function MinecraftRadialButton({text, value, selected, className, onChange}: RadialButtonProperties) {
     return (
-        <div className={`w-full h-full ${className}`}>
-            <div className="h-[51px]" onClick={() => onChange(text)}>
+        <div className={`w-full h-full m-[-1.5px] ${className}`}>
+            <div className="h-[51px]" onClick={() => onChange(value)}>
 
-                <div className={`border-[3px] border-[#1E1E1F] cursor-pointer ${selected ? "translate-y-[4px] h-[46px]" : "h-full" }`}>
+                <div className={`border-[3px] border-[#1E1E1F] cursor-pointer ${selected ? "translate-y-[5px] h-[46px]" : "h-full" }`}>
 
                     {
-                        selected ?
-
+                        selected 
+                        
+                        ?
+                            
+                        (
                             <div className="relative border-[3px] h-[40px] box-border flex items-center justify-center border-[#4F913C] bg-[#3C8527]">
                                 <p className="minecraft-seven text-[16px] text-white">{text}</p>
                                 <div className="absolute bg-[#FFFFFF] h-[3px] w-[60px] bottom-[-3px]"/>
                             </div>
-                            
+                        )
 
                         :
 
-                        <div className="border-[3px] h-[40px] box-border flex items-center justify-center border-[#e3e3e5] bg-[#d0d1d4] hover:bg-[#b1b2b5]">
-                            <p className="minecraft-seven text-[16px] text-[#1e1e1f]">{text}</p>
-                        </div>
+                        (
+                            <div className="border-[3px] h-[40px] box-border flex items-center justify-center border-[#e3e3e5] bg-[#d0d1d4] hover:bg-[#b1b2b5]">
+                                <p className="minecraft-seven text-[16px] text-[#1e1e1f]">{text}</p>
+                            </div> 
+                        )
                     }
 
 

--- a/src/components/MinecraftRadialButtonPanel.tsx
+++ b/src/components/MinecraftRadialButtonPanel.tsx
@@ -1,24 +1,35 @@
 import { useState } from "react";
 import MinecraftRadialButton from "./MinecraftRadialButton";
-import { useAppState } from "../contexts/AppState";
 
-export default function MinecraftRadialButtonPanel() {
-    const {UITheme, setUITheme} = useAppState();
+type RadialButtonPanelProperties = {
+    elements: {
+        text: string,
+        value: string,
+        className?: string,
+    }[]
 
-    const [selectedValue, setSelectedValue] = useState(UITheme);
+    default_selected_value?: string,
 
+    onChange: (selected_value: string) => void,
+}
 
-    function handleSelectionChange(text: string) {
-        setSelectedValue(text)
+export default function MinecraftRadialButtonPanel({elements, default_selected_value, onChange}: RadialButtonPanelProperties) {
+    const [selected_value, setSelectedValue] = useState(default_selected_value);
 
-        setUITheme(text)
+    function handleSelect(value: string) {
+        setSelectedValue(value)
+        onChange(value)
     }
 
     return (
-        <div className="w-full h-full flex items-center justify-center">
-            <MinecraftRadialButton text="Light" onChange={(text) => {handleSelectionChange(text)}} selected={selectedValue == 'Light'}></MinecraftRadialButton>
-            <MinecraftRadialButton className="mx-[8px]" text="Dark" onChange={(text) => {handleSelectionChange(text)}} selected={selectedValue == 'Dark'}></MinecraftRadialButton>
-            <MinecraftRadialButton text="System" onChange={(text) => {handleSelectionChange(text)}} selected={selectedValue == 'System'}></MinecraftRadialButton>
-        </div>
+        <>
+            <div className="flex items-center justify-center">
+                {
+                    elements.map(element => {
+                        return <MinecraftRadialButton text={element.text} value={element.value} selected={selected_value === element.value} className={element.className} onChange={handleSelect}/>
+                    })
+                }
+            </div>
+        </>
     )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -10,7 +10,6 @@ import { isDeveloperModeEnabled } from "../versionSwitcher/DeveloperMode";
 import ReadOnlyTextBox from "../components/ReadOnlyTextBox";
 import { useEffect, useState } from "react";
 import MinecraftToggle from "../components/MinecraftToggle"
-import MinecraftRadialButton from "../components/MinecraftRadialButton";
 import MinecraftRadialButtonPanel from "../components/MinecraftRadialButtonPanel";
 
 const fs = window.require('fs') as typeof import('fs');
@@ -88,7 +87,7 @@ export default function SettingsPage() {
 
             <div className="w-full border-y-[2px] border-solid border-b-[#1E1E1F] border-t-[#5A5B5C] p-[8px] bg-[#48494A]">
                 <p className="minecraft-seven text-white text-[14px]">UI Theme</p>
-                <MinecraftRadialButtonPanel></MinecraftRadialButtonPanel>
+                <MinecraftRadialButtonPanel elements={[{text: "Light", value: "Light"}, {text: "Dark", value: "Dark"}, {text:"System", value:"System"}]} default_selected_value={UITheme} onChange={(value => { setUITheme(value) })}/>
             </div>
 
             <DividedSection className="minecraft-seven text-[#BCBEC0] text-[14px]">

--- a/src/styles/switch.css
+++ b/src/styles/switch.css
@@ -134,14 +134,14 @@
 }
 
 #switch_toggle_side.large {
-    height: 6px;
-    width: 36px;
+    height: 5px;
+    width: 35px;
     background-color: #58585A;
 }
 
 #switch_toggle_side {
-    height: 6px;
-    width: 26px;
+    height: 5px;
+    width: 25px;
     background-color: #58585A;
 }
 


### PR DESCRIPTION
Disabled Zoom functionality in the app so UI doesn't break.

Generalised the MinecraftRadialButtonPanel, it now takes in an array of element properties, and returns the value associated with the MinecraftRadialButton when it is selected.

Fixed some other bugs and reverted the element sizes of the MinecraftToggle back to normal.