### PR TITLE
Support importing mods by dropping Zips or Folders (Continued with improved error handling)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.4.7",
       "dependencies": {
         "electron-updater": "^6.2.1",
+        "fflate": "^0.8.2",
         "jszip": "^3.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4178,6 +4179,11 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "electron-updater": "^6.2.1",
+    "fflate": "^0.8.2",
     "jszip": "^3.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ProfilePage from "./pages/ProfilePage";
 import SettingsPage from "./pages/SettingsPage";
 import UpdatePage from "./pages/UpdatePage";
 import ModsPage from "./pages/ModsPage";
+import DropWindow from "./components/DropWindow";
 
 export default function App() {
     
@@ -67,6 +68,8 @@ export default function App() {
 
                 <UpdatePage></UpdatePage>
             </div>
+
+            <DropWindow />
         </AppStateProvider>
     )
 }

--- a/src/components/DropWindow.tsx
+++ b/src/components/DropWindow.tsx
@@ -1,0 +1,173 @@
+import { unzipSync } from 'fflate'
+import { useEffect, useState } from 'react'
+import { getModsFolder } from '../versionSwitcher/AmethystPaths'
+
+const fs = window.require('fs') as typeof import('fs')
+const path = window.require('path') as typeof import('path')
+
+export default function DropWindow() {
+	const [hovered, setHovered] = useState(false)
+
+	let dragCount = 0
+
+	useEffect(() => {
+		function dragOver(event: DragEvent) {
+			event.preventDefault()
+		}
+
+		function dragStart(event: DragEvent) {
+			event.preventDefault()
+
+			if (dragCount === 0) setHovered(true)
+
+			dragCount++
+		}
+
+		function dragEnd(event: DragEvent) {
+			event.preventDefault()
+
+			dragCount--
+
+			if (dragCount === 0) setHovered(false)
+		}
+
+		function drop(event: DragEvent) {
+			event.preventDefault()
+
+			setHovered(false)
+
+			dragCount = 0
+
+			if (!event.dataTransfer) return
+
+			const items = event.dataTransfer.items
+
+			for (const item of items) {
+				const entry = item.webkitGetAsEntry()
+
+				if (!entry) continue
+
+				if (entry.isFile) importZip(entry as FileSystemFileEntry)
+				if (entry.isDirectory)
+					importFolder(entry as FileSystemDirectoryEntry)
+			}
+		}
+
+		function importZip(file: FileSystemFileEntry) {
+			file.file((blob) => {
+				const reader = new FileReader()
+
+				reader.onload = (event) => {
+					const data = new Uint8Array(reader.result as ArrayBuffer)
+
+					const unzipped = unzipSync(data)
+
+					const modsFolderPath = getModsFolder()
+					const modFolderPath = path.join(
+						modsFolderPath,
+						path.basename(file.name, path.extname(file.name))
+					)
+
+					for (const [filePath, fileContent] of Object.entries(
+						unzipped
+					)) {
+						const absoluteFilePath = path.join(
+							modFolderPath,
+							filePath
+						)
+
+						if (!fs.existsSync(path.dirname(absoluteFilePath)))
+							fs.mkdirSync(path.dirname(absoluteFilePath), {
+								recursive: true,
+							})
+
+						if (absoluteFilePath.endsWith('\\')) {
+							fs.mkdirSync(absoluteFilePath)
+						} else {
+							fs.writeFileSync(absoluteFilePath, fileContent)
+						}
+					}
+				}
+
+				reader.readAsArrayBuffer(blob)
+			})
+		}
+
+		function importFolder(folder: FileSystemDirectoryEntry) {
+			const modsFolderPath = getModsFolder()
+			const modPath = path.join(modsFolderPath, folder.name)
+
+			if (fs.existsSync(modPath))
+				fs.rmdirSync(modPath, { recursive: true })
+
+			fs.mkdirSync(modPath)
+
+			saveFolderTo(modPath, folder)
+		}
+
+		function saveFolderTo(
+			destination: string,
+			folder: FileSystemDirectoryEntry
+		) {
+			const reader = folder.createReader()
+
+			reader.readEntries((entries) => {
+				for (const entry of entries) {
+					if (entry.isFile) {
+						;(entry as FileSystemFileEntry).file((blob) => {
+							const reader = new FileReader()
+
+							reader.onload = (event) => {
+								const data = new Uint8Array(
+									reader.result as ArrayBuffer
+								)
+
+								fs.writeFileSync(
+									path.join(destination, entry.name),
+									data
+								)
+							}
+
+							reader.readAsArrayBuffer(blob)
+						})
+					} else {
+						const folderPath = path.join(destination, entry.name)
+
+						fs.mkdirSync(folderPath)
+
+						saveFolderTo(
+							folderPath,
+							entry as FileSystemDirectoryEntry
+						)
+					}
+				}
+			})
+		}
+
+		window.addEventListener('dragover', dragOver)
+		window.addEventListener('dragenter', dragStart)
+		window.addEventListener('dragleave', dragEnd)
+		window.addEventListener('drop', drop)
+
+		return () => {
+			window.removeEventListener('dragover', dragOver)
+			window.removeEventListener('dragenter', dragStart)
+			window.removeEventListener('dragleave', dragEnd)
+			window.removeEventListener('drop', drop)
+		}
+	}, [])
+
+	return (
+		<div
+			className={`absolute w-full h-full top-0 left-0 pointer-events-none ${
+				hovered ? 'opacity-100' : 'opacity-0'
+			} transition-opacity ease-out duration-150`}
+		>
+			<div className="absolute pointer-events-none w-full h-full bg-black top-0 left-0 opacity-80" />
+
+			<h1 className="minecraft-seven pointer-events-none text-white absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%]">
+				Drop mod .zip or folder to import
+			</h1>
+		</div>
+	)
+}

--- a/src/contexts/AppState.tsx
+++ b/src/contexts/AppState.tsx
@@ -1,151 +1,188 @@
-import {createContext, ReactNode, useCallback, useContext, useEffect, useState} from "react";
-import {Profile} from "../types/Profile";
 import {
-    findAllMods,
-    findAllProfiles,
-    getAllMinecraftVersions,
-    readLauncherConfig,
-    saveAllProfiles,
-    saveLauncherConfig
-} from "../launcher/Modlist";
-import {LauncherConfig} from "../types/LauncherConfig";
-import {MinecraftVersion} from "../types/MinecraftVersion";
-import { ipcRenderer } from "electron";
+	createContext,
+	ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react'
+import { Profile } from '../types/Profile'
+import {
+	findAllMods,
+	findAllProfiles,
+	getAllMinecraftVersions,
+	readLauncherConfig,
+	saveAllProfiles,
+	saveLauncherConfig,
+} from '../launcher/Modlist'
+import { LauncherConfig } from '../types/LauncherConfig'
+import { MinecraftVersion } from '../types/MinecraftVersion'
+import { ipcRenderer } from 'electron'
 
 interface TAppStateContext {
-    allMods: string[];
-    setAllMods: React.Dispatch<React.SetStateAction<string[]>>;
+	allMods: string[]
+	setAllMods: React.Dispatch<React.SetStateAction<string[]>>
 
-    allRuntimes: string[];
-    setAllRuntimes: React.Dispatch<React.SetStateAction<string[]>>;
+	allRuntimes: string[]
+	setAllRuntimes: React.Dispatch<React.SetStateAction<string[]>>
 
-    allMinecraftVersions: MinecraftVersion[];
-    setAllMinecraftVersions: React.Dispatch<React.SetStateAction<MinecraftVersion[]>>;
+	allMinecraftVersions: MinecraftVersion[]
+	setAllMinecraftVersions: React.Dispatch<
+		React.SetStateAction<MinecraftVersion[]>
+	>
 
-    allProfiles: Profile[];
-    setAllProfiles: React.Dispatch<React.SetStateAction<Profile[]>>;
+	allProfiles: Profile[]
+	setAllProfiles: React.Dispatch<React.SetStateAction<Profile[]>>
 
-    selectedProfile: number;
-    setSelectedProfile: React.Dispatch<React.SetStateAction<number>>;
+	selectedProfile: number
+	setSelectedProfile: React.Dispatch<React.SetStateAction<number>>
 
-    UITheme: string;
-    setUITheme: React.Dispatch<React.SetStateAction<string>>;
+	UITheme: string
+	setUITheme: React.Dispatch<React.SetStateAction<string>>
 
-    keepLauncherOpen: boolean;
-    setKeepLauncherOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	keepLauncherOpen: boolean
+	setKeepLauncherOpen: React.Dispatch<React.SetStateAction<boolean>>
 
-    developerMode: boolean;
-    setDeveloperMode: React.Dispatch<React.SetStateAction<boolean>>;
+	developerMode: boolean
+	setDeveloperMode: React.Dispatch<React.SetStateAction<boolean>>
 
-    loadingPercent: number;
-    setLoadingPercent: React.Dispatch<React.SetStateAction<number>>;
+	loadingPercent: number
+	setLoadingPercent: React.Dispatch<React.SetStateAction<number>>
 
-    isLoading: boolean;
-    setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+	isLoading: boolean
+	setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 
-    status: string;
-    setStatus: React.Dispatch<React.SetStateAction<string>>;
+	status: string
+	setStatus: React.Dispatch<React.SetStateAction<string>>
 
-    error: string;
-    setError: React.Dispatch<React.SetStateAction<string>>;
+	error: string
+	setError: React.Dispatch<React.SetStateAction<string>>
 
-    // Expose functions
-    saveData: () => void
+	errorType: 'launch' | 'import'
+	setErrorType: React.Dispatch<React.SetStateAction<'launch' | 'import'>>
+
+	// Expose functions
+	saveData: () => void
 }
 
-const AppStateContext = createContext<TAppStateContext | undefined>(undefined);
+const AppStateContext = createContext<TAppStateContext | undefined>(undefined)
 
-export const AppStateProvider = ({children}: { children: ReactNode }) => {
-    const [allMods, setAllMods] = useState<string[]>([]);
-    const [allRuntimes, setAllRuntimes] = useState<string[]>([]);
-    const [allMinecraftVersions, setAllMinecraftVersions] = useState<MinecraftVersion[]>([]);
-    const [allProfiles, setAllProfiles] = useState<Profile[]>([]);
-    const [selectedProfile, setSelectedProfile] = useState(0);
-    const [UITheme, setUITheme] = useState("System");
-    const [keepLauncherOpen, setKeepLauncherOpen] = useState(true);
-    const [developerMode, setDeveloperMode] = useState(false);
-    const [loadingPercent, setLoadingPercent] = useState(0);
-    const [isLoading, setIsLoading] = useState(false);
-    const [status, setStatus] = useState("");
-    const [error, setError] = useState("");
+export const AppStateProvider = ({ children }: { children: ReactNode }) => {
+	const [allMods, setAllMods] = useState<string[]>([])
+	const [allRuntimes, setAllRuntimes] = useState<string[]>([])
+	const [allMinecraftVersions, setAllMinecraftVersions] = useState<
+		MinecraftVersion[]
+	>([])
+	const [allProfiles, setAllProfiles] = useState<Profile[]>([])
+	const [selectedProfile, setSelectedProfile] = useState(0)
+	const [UITheme, setUITheme] = useState('System')
+	const [keepLauncherOpen, setKeepLauncherOpen] = useState(true)
+	const [developerMode, setDeveloperMode] = useState(false)
+	const [loadingPercent, setLoadingPercent] = useState(0)
+	const [isLoading, setIsLoading] = useState(false)
+	const [status, setStatus] = useState('')
+	const [error, setError] = useState('')
+	const [errorType, setErrorType] = useState<'launch' | 'import'>('launch')
 
-    // Initialize Data like all mods and existing profiles..
-    useEffect(() => {
-        setAllProfiles(findAllProfiles());
+	// Initialize Data like all mods and existing profiles..
+	useEffect(() => {
+		setAllProfiles(findAllProfiles())
 
-        const modList = findAllMods();
-        setAllRuntimes(["Vanilla", ...modList.runtimeMods]);
-        setAllMods(modList.mods);
+		const modList = findAllMods()
+		setAllRuntimes(['Vanilla', ...modList.runtimeMods])
+		setAllMods(modList.mods)
 
-        const readConfig = readLauncherConfig();
-        setKeepLauncherOpen(readConfig.keep_open ?? true);
-        setDeveloperMode(readConfig.developer_mode ?? false);
-        setSelectedProfile(readConfig.selected_profile ?? 0);
-        setUITheme(readConfig.ui_theme ?? "Light");
+		const readConfig = readLauncherConfig()
+		setKeepLauncherOpen(readConfig.keep_open ?? true)
+		setDeveloperMode(readConfig.developer_mode ?? false)
+		setSelectedProfile(readConfig.selected_profile ?? 0)
+		setUITheme(readConfig.ui_theme ?? 'Light')
 
-        const fetchMinecraftVersions = async () => {
-            const versions = await getAllMinecraftVersions();
-            setAllMinecraftVersions(versions);
-        }
+		const fetchMinecraftVersions = async () => {
+			const versions = await getAllMinecraftVersions()
+			setAllMinecraftVersions(versions)
+		}
 
-        fetchMinecraftVersions();
-    }, [])
+		fetchMinecraftVersions()
+	}, [])
 
-    const [hasInitialized, setHasInitialized] = useState(false);
+	const [hasInitialized, setHasInitialized] = useState(false)
 
-    const saveData = useCallback(() => {
-        saveAllProfiles(allProfiles);
+	const saveData = useCallback(() => {
+		saveAllProfiles(allProfiles)
 
-        const launcherConfig: LauncherConfig = {
-            developer_mode: developerMode,
-            keep_open: keepLauncherOpen,
-            mods: allProfiles[selectedProfile]?.mods ?? [],
-            runtime: allProfiles[selectedProfile]?.runtime ?? "",
-            selected_profile: selectedProfile,
-            ui_theme: UITheme
-        };
+		const launcherConfig: LauncherConfig = {
+			developer_mode: developerMode,
+			keep_open: keepLauncherOpen,
+			mods: allProfiles[selectedProfile]?.mods ?? [],
+			runtime: allProfiles[selectedProfile]?.runtime ?? '',
+			selected_profile: selectedProfile,
+			ui_theme: UITheme,
+		}
 
-        saveLauncherConfig(launcherConfig);
-    }, [allProfiles, developerMode, keepLauncherOpen, selectedProfile, UITheme])
+		saveLauncherConfig(launcherConfig)
+	}, [allProfiles, developerMode, keepLauncherOpen, selectedProfile, UITheme])
 
-    useEffect(() => {
-        if (!hasInitialized) {
-            setHasInitialized(true);
-            return;
-        }
+	useEffect(() => {
+		if (!hasInitialized) {
+			setHasInitialized(true)
+			return
+		}
 
-        saveData();
-    }, [allProfiles, selectedProfile, keepLauncherOpen, developerMode, hasInitialized, saveData])
+		saveData()
+	}, [
+		allProfiles,
+		selectedProfile,
+		keepLauncherOpen,
+		developerMode,
+		hasInitialized,
+		saveData,
+	])
 
-    useEffect(() => {
-        ipcRenderer.send('WINDOW_UI_THEME', UITheme)
-    }, [UITheme])
+	useEffect(() => {
+		ipcRenderer.send('WINDOW_UI_THEME', UITheme)
+	}, [UITheme])
 
-    return (
-        <AppStateContext.Provider value={
-            {
-                allMods, setAllMods,
-                allRuntimes, setAllRuntimes,
-                allMinecraftVersions, setAllMinecraftVersions,
-                allProfiles, setAllProfiles,
-                selectedProfile, setSelectedProfile,
-                UITheme, setUITheme,
-                keepLauncherOpen, setKeepLauncherOpen,
-                developerMode, setDeveloperMode,
-                loadingPercent, setLoadingPercent,
-                isLoading, setIsLoading,
-                status, setStatus,
-                saveData,
-                error, setError
-            }
-        }>
-            {children}
-        </AppStateContext.Provider>
-    )
+	return (
+		<AppStateContext.Provider
+			value={{
+				allMods,
+				setAllMods,
+				allRuntimes,
+				setAllRuntimes,
+				allMinecraftVersions,
+				setAllMinecraftVersions,
+				allProfiles,
+				setAllProfiles,
+				selectedProfile,
+				setSelectedProfile,
+				UITheme,
+				setUITheme,
+				keepLauncherOpen,
+				setKeepLauncherOpen,
+				developerMode,
+				setDeveloperMode,
+				loadingPercent,
+				setLoadingPercent,
+				isLoading,
+				setIsLoading,
+				status,
+				setStatus,
+				saveData,
+				error,
+				setError,
+				errorType,
+				setErrorType,
+			}}
+		>
+			{children}
+		</AppStateContext.Provider>
+	)
 }
 
 export const useAppState = () => {
-    const context = useContext(AppStateContext);
-    if (!context) throw new Error('useAppState must be used within a MyProvider');
-    return context;
-};
+	const context = useContext(AppStateContext)
+	if (!context)
+		throw new Error('useAppState must be used within a MyProvider')
+	return context
+}

--- a/src/pages/LauncherPage.tsx
+++ b/src/pages/LauncherPage.tsx
@@ -1,158 +1,231 @@
-import Dropdown from "../components/Dropdown";
-import MainPanel from "../components/MainPanel";
-import MinecraftButton from "../components/MinecraftButton";
-import {useAppState} from "../contexts/AppState";
-import {SemVersion} from "../types/SemVersion";
-import {readLauncherConfig, saveLauncherConfig} from "../launcher/Modlist";
-import { isDeveloperModeEnabled, tryEnableDeveloperMode } from "../versionSwitcher/DeveloperMode";
-import { registerVersion, unregisterExisting } from "../versionSwitcher/AppRegistry";
-import { cleanupFailedInstall, cleanupSuccessfulInstall, copyProxyToInstalledVer, createLockFile, downloadVersion, extractVersion, isLockFilePresent, isRegisteredVersionOurs, isVersionDownloaded } from "../versionSwitcher/VersionManager";
+import Dropdown from '../components/Dropdown'
+import MainPanel from '../components/MainPanel'
+import MinecraftButton from '../components/MinecraftButton'
+import { useAppState } from '../contexts/AppState'
+import { SemVersion } from '../types/SemVersion'
+import { readLauncherConfig, saveLauncherConfig } from '../launcher/Modlist'
+import {
+	isDeveloperModeEnabled,
+	tryEnableDeveloperMode,
+} from '../versionSwitcher/DeveloperMode'
+import {
+	registerVersion,
+	unregisterExisting,
+} from '../versionSwitcher/AppRegistry'
+import {
+	cleanupFailedInstall,
+	cleanupSuccessfulInstall,
+	copyProxyToInstalledVer,
+	createLockFile,
+	downloadVersion,
+	extractVersion,
+	isLockFilePresent,
+	isRegisteredVersionOurs,
+	isVersionDownloaded,
+} from '../versionSwitcher/VersionManager'
 
 const child = window.require('child_process') as typeof import('child_process')
 
 export default function LauncherPage() {
-    const {
-        allProfiles, selectedProfile, setSelectedProfile, loadingPercent, status, setStatus, isLoading, setIsLoading,
-        setLoadingPercent, allMinecraftVersions, error, setError
-    } = useAppState();
+	const {
+		allProfiles,
+		selectedProfile,
+		setSelectedProfile,
+		loadingPercent,
+		status,
+		setStatus,
+		isLoading,
+		setIsLoading,
+		setLoadingPercent,
+		allMinecraftVersions,
+		error,
+		setError,
+		errorType,
+		setErrorType,
+	} = useAppState()
 
-    const log = (msg: string) => {
-        console.log(msg)
-        setStatus(msg)
-    }
+	const log = (msg: string) => {
+		console.log(msg)
+		setStatus(msg)
+	}
 
-    const launchGame = async () => {
-        if (isLoading) return;
+	const launchGame = async () => {
+		if (isLoading) return
 
-        try {
-            if (allProfiles.length === 0) {
-                throw new Error("Cannot launch without a profile!")
-            }
+		try {
+			if (allProfiles.length === 0) {
+				throw new Error('Cannot launch without a profile!')
+			}
 
-            const profile = allProfiles[selectedProfile];
-            const semVersion = SemVersion.fromString(profile.minecraft_version);
-            const minecraftVersion = allMinecraftVersions.find(version => version.version.toString() === semVersion.toString())!;
+			const profile = allProfiles[selectedProfile]
+			const semVersion = SemVersion.fromString(profile.minecraft_version)
+			const minecraftVersion = allMinecraftVersions.find(
+				(version) =>
+					version.version.toString() === semVersion.toString()
+			)!
 
-            if (minecraftVersion === undefined) {
-                throw new Error(`Failed to find minecraft version ${semVersion.toString()} in the profile in allVersions!`);
-            }
+			if (minecraftVersion === undefined) {
+				throw new Error(
+					`Failed to find minecraft version ${semVersion.toString()} in the profile in allVersions!`
+				)
+			}
 
-            setError("");
-            setIsLoading(true);
+			setError('')
+			setErrorType('launch')
+			setIsLoading(true)
 
-            // Check that the user has developer mode enabled on windows for the game to be installed through loose files.
-            if (!isDeveloperModeEnabled()) {
-                const couldEnableDev = await tryEnableDeveloperMode();
-                if (!couldEnableDev) {
-                    throw new Error("Failed to enable 'Developer Mode' in windows settings to allow installing the game from loose files, please enable manually or make sure to press 'Yes' to enable automatically.")
-                }
-            }
+			// Check that the user has developer mode enabled on windows for the game to be installed through loose files.
+			if (!isDeveloperModeEnabled()) {
+				const couldEnableDev = await tryEnableDeveloperMode()
+				if (!couldEnableDev) {
+					throw new Error(
+						"Failed to enable 'Developer Mode' in windows settings to allow installing the game from loose files, please enable manually or make sure to press 'Yes' to enable automatically."
+					)
+				}
+			}
 
-            // We create a lock file when starting the download
-            // if we are doing a launch, and we detect it for the version we are targeting
-            // there is a good chance the previous install/download failed and therefore remove it.
-            const didPreviousDownloadFail = isLockFilePresent(semVersion);
-            
-            if (didPreviousDownloadFail) {
-                log("Detected a .lock file from the previous download attempt, cleaning up.");
-                cleanupFailedInstall(semVersion);
-                log("Removed previous download attempt.");
-            }
+			// We create a lock file when starting the download
+			// if we are doing a launch, and we detect it for the version we are targeting
+			// there is a good chance the previous install/download failed and therefore remove it.
+			const didPreviousDownloadFail = isLockFilePresent(semVersion)
 
-            // Check for the folder for the version we are targeting, if not present we need to fetch.
-            if (!isVersionDownloaded(semVersion)) {
-                log("Target version is not downloaded.");
-                createLockFile(semVersion);
-                await downloadVersion(minecraftVersion, setStatus, setLoadingPercent);
-                await extractVersion(minecraftVersion, setStatus, setLoadingPercent);
-                log("Cleaning up after successful download")
-                cleanupSuccessfulInstall(semVersion);
-            }
+			if (didPreviousDownloadFail) {
+				log(
+					'Detected a .lock file from the previous download attempt, cleaning up.'
+				)
+				cleanupFailedInstall(semVersion)
+				log('Removed previous download attempt.')
+			}
 
-            // Only register the game if needed
-            if (!isRegisteredVersionOurs(minecraftVersion)) {
-                setStatus("Unregistering existing version");
-                await unregisterExisting();
+			// Check for the folder for the version we are targeting, if not present we need to fetch.
+			if (!isVersionDownloaded(semVersion)) {
+				log('Target version is not downloaded.')
+				createLockFile(semVersion)
+				await downloadVersion(
+					minecraftVersion,
+					setStatus,
+					setLoadingPercent
+				)
+				await extractVersion(
+					minecraftVersion,
+					setStatus,
+					setLoadingPercent
+				)
+				log('Cleaning up after successful download')
+				cleanupSuccessfulInstall(semVersion)
+			}
 
-                setStatus("Registering downloaded version");
-                await registerVersion(minecraftVersion)
+			// Only register the game if needed
+			if (!isRegisteredVersionOurs(minecraftVersion)) {
+				setStatus('Unregistering existing version')
+				await unregisterExisting()
 
-                saveLauncherConfig(readLauncherConfig());
-            }
+				setStatus('Registering downloaded version')
+				await registerVersion(minecraftVersion)
 
-            setIsLoading(false);
-            setStatus("");
+				saveLauncherConfig(readLauncherConfig())
+			}
 
-            copyProxyToInstalledVer(minecraftVersion);
+			setIsLoading(false)
+			setStatus('')
 
-            const startGameCmd = `start minecraft:`;
-            child.exec(startGameCmd)
-        } catch (e: unknown) {
-            console.log(e);
-            setError((e as Error).message);
-            setStatus("");
-            setIsLoading(false);
-        }
-    }
+			copyProxyToInstalledVer(minecraftVersion)
 
-    return (
-        <MainPanel>
+			const startGameCmd = `start minecraft:`
+			child.exec(startGameCmd)
+		} catch (e: unknown) {
+			console.log(e)
+			setError((e as Error).message)
+			setStatus('')
+			setIsLoading(false)
+		}
+	}
 
-            {error === "" ? <></> : (
-                    <>
-                        <div className="bg-red-500 w-full">
-                            <p className="minecraft-seven text-[14px]">There was an error while trying to launch the
-                                game!</p>
-                            <div className="bg-red-600 h-[2px] w-full min-h-[2px]"></div>
-                            <p className="minecraft-seven text-[13px]">{error}</p>
-                        </div>
-                        <div className="bg-red-600 h-[2px] w-full min-h-[2px]"></div>
-                    </>
-                )
-            }
+	return (
+		<MainPanel>
+			{error === '' ? (
+				<></>
+			) : (
+				<>
+					<div className="bg-red-500 w-full">
+						{errorType === 'launch' ? (
+							<p className="minecraft-seven text-[14px]">
+								There was an error while trying to launch the
+								game!
+							</p>
+						) : (
+							<p className="minecraft-seven text-[14px]">
+								There was an error while trying to import a mod!
+							</p>
+						)}
+						<div className="bg-red-600 h-[2px] w-full min-h-[2px]"></div>
+						<p className="minecraft-seven text-[13px]">{error}</p>
+					</div>
+					<div className="bg-red-600 h-[2px] w-full min-h-[2px]"></div>
+				</>
+			)}
 
-            <div className="flex-group">
-                <img src="images/art/lush_cave.png" className="object-cover w-full h-full min-h-screen" alt="" />
-            </div>
+			<div className="flex-group">
+				<img
+					src="images/art/lush_cave.png"
+					className="object-cover w-full h-full min-h-screen"
+					alt=""
+				/>
+			</div>
 
-            <div className="fixed bottom-0 right-0 left-[66px]">
-                {/* Not affliated disclaimer */}
-                <div className="bg-[#0c0c0cc5] w-fit ml-auto">
-                    <p className="minecraft-seven text-white px-[4px] text-[13px]">Not approved by or associated with
-                        Mojang or Microsoft</p>
-                </div>
+			<div className="fixed bottom-0 right-0 left-[66px]">
+				{/* Not affliated disclaimer */}
+				<div className="bg-[#0c0c0cc5] w-fit ml-auto">
+					<p className="minecraft-seven text-white px-[4px] text-[13px]">
+						Not approved by or associated with Mojang or Microsoft
+					</p>
+				</div>
 
-                {/* Loading bar */}
-                <div
-                    className={`bg-[#313233] ${isLoading ? "h-[25px]" : "h-0"} transition-all duration-300 ease-in-out`}>
-                    <div
-                        className={`bg-[#3C8527] absolute ${isLoading ? "min-h-[25px]" : "min-h-0"} transition-all duration-300 ease-in-out`}
-                        style={{width: `${loadingPercent * 100}%`}}
-                    ></div>
-                    <p className='minecraft-seven absolute z-30 text-white overflow-hidden text-ellipsis whitespace-nowrap max-w-full px-2'>{status}</p>
-                </div>
+				{/* Loading bar */}
+				<div
+					className={`bg-[#313233] ${
+						isLoading ? 'h-[25px]' : 'h-0'
+					} transition-all duration-300 ease-in-out`}
+				>
+					<div
+						className={`bg-[#3C8527] absolute ${
+							isLoading ? 'min-h-[25px]' : 'min-h-0'
+						} transition-all duration-300 ease-in-out`}
+						style={{ width: `${loadingPercent * 100}%` }}
+					></div>
+					<p className="minecraft-seven absolute z-30 text-white overflow-hidden text-ellipsis whitespace-nowrap max-w-full px-2">
+						{status}
+					</p>
+				</div>
 
-                {/* Profile Selector & Play Button */}
-                <div className="flex gap-[8px] border-b-[0px] pb-1 border-t-[#1E1E1F] border-y-[2px] border-solid border-b-[#1E1E1F] p-[8px] bg-[#48494A]">
-                    <div className="w-[30%] translate-y-[-1px]">
-                        <Dropdown
-                            labelText="Profile"
-                            options={allProfiles?.map(profile => profile.name)}
-                            value={allProfiles[selectedProfile]?.name}
-                            setValue={(value) => {
-                                setSelectedProfile(allProfiles.map(profile => profile.name).findIndex(e => e === value));
-                            }}
-                            id="profile-select"
-                        />
-                    </div>
+				{/* Profile Selector & Play Button */}
+				<div className="flex gap-[8px] border-b-[0px] pb-1 border-t-[#1E1E1F] border-y-[2px] border-solid border-b-[#1E1E1F] p-[8px] bg-[#48494A]">
+					<div className="w-[30%] translate-y-[-1px]">
+						<Dropdown
+							labelText="Profile"
+							options={allProfiles?.map(
+								(profile) => profile.name
+							)}
+							value={allProfiles[selectedProfile]?.name}
+							setValue={(value) => {
+								setSelectedProfile(
+									allProfiles
+										.map((profile) => profile.name)
+										.findIndex((e) => e === value)
+								)
+							}}
+							id="profile-select"
+						/>
+					</div>
 
-                    <div className="w-[70%]">
-                        <MinecraftButton text="Launch Game" onClick={launchGame}/>
-                    </div>
-
-                </div>
-            </div>
-
-        </MainPanel>
-    )
+					<div className="w-[70%]">
+						<MinecraftButton
+							text="Launch Game"
+							onClick={launchGame}
+						/>
+					</div>
+				</div>
+			</div>
+		</MainPanel>
+	)
 }


### PR DESCRIPTION
Continues #39 

# Changes
- Adds error handling and message if the import for some reason fails to work
- Adds errorType to app state to change error message when launching game vs importing mods

# Fixes
- Fixed importing zip mods breaking if recursive folders used

What it looks like when an error is thrown while importing a mod. Just threw a custom error called 'Cheese' for demonstration.
![image](https://github.com/FrederoxDev/Amethyst-Launcher/assets/60296487/01f0071c-a221-43be-9318-56ae0e664dd4)
